### PR TITLE
fix imports to resolve deprecation warnings in python 3.8

### DIFF
--- a/revisiondict/revisiondict.py
+++ b/revisiondict/revisiondict.py
@@ -54,11 +54,12 @@ Update items:
 ('b', 'c', 'a')
 """
 
-import collections
 import bisect
+from collections import namedtuple
+from collections.abc import MutableMapping
 
 
-class _Item(collections.namedtuple('_Item', 'key value revision')):
+class _Item(namedtuple('_Item', 'key value revision')):
     """ _Item representing a key:value pair with information about the revision
     this update was done.
     """
@@ -68,7 +69,7 @@ class _Item(collections.namedtuple('_Item', 'key value revision')):
         return self.revision < other.revision
 
 
-class RevisionDict(collections.MutableMapping):
+class RevisionDict(MutableMapping):
     def __init__(self, *args, **kwargs):
         self._items = list()  # keep _Item objs, guaranteed sorted by revision
         self._key_to_index = dict()  # dict indexing position of key in _items


### PR DESCRIPTION
Using or importing the ABCs from 'collections'  throws a `DepracationWarning` (see screenshot below).

![deprecation_warning](https://user-images.githubusercontent.com/1737745/85507670-0859ba80-b5f3-11ea-98a1-5218f556c0f7.png)

Importing from 'collections.abc' fixes it.